### PR TITLE
Fix to allow specification of damage type in assign damage macro

### DIFF
--- a/src/module/rolls/assign-damage-data.mjs
+++ b/src/module/rolls/assign-damage-data.mjs
@@ -1,11 +1,12 @@
 import { hitDropdown } from '../rules/hit-locations.mjs';
 import { getCriticalDamage } from '../rules/critical-damage.mjs';
+import { damageTypeDropdown } from '../rules/damage-type.mjs';
 
 export class AssignDamageData {
     locations = hitDropdown();
     actor;
     hit;
-
+    damageType = damageTypeDropdown();
     ignoreArmour = false;
 
     armour = 0;

--- a/src/module/rules/damage-type.mjs
+++ b/src/module/rules/damage-type.mjs
@@ -1,0 +1,28 @@
+export function damageTypeDropdown() {
+    const dropdown = {};
+    damageType().forEach((i) => {
+        dropdown[i.name] = i.name;
+    });
+    return dropdown;
+}
+
+export function damageTypeNames() {
+    return damageType().map((i) => i.name);
+}
+
+export function damageType() {
+    return [
+        {
+            name: 'Energy',
+        },
+        {
+            name: 'Explosive',
+        },
+        {
+            name: 'Impact',
+        },
+        {
+            name: 'Rending',
+        },
+    ];
+}

--- a/src/templates/prompt/assign-damage-prompt.hbs
+++ b/src/templates/prompt/assign-damage-prompt.hbs
@@ -41,7 +41,12 @@
                         </div>
                     </div>
                 </div>
-
+                <div class="dh-field__wrapper">
+                    <span class="dh-field__span">Damage Type</span>
+                    <select class="dh-field__input" name="hit.damageType" id="damageType">
+                        {{selectOptions damageType selected=this.hit.damageType}}
+                    </select>
+                </div>
                 <div class="dh-field__wrapper">
                     <span class="dh-field__span">Damage</span>
                     <input class="dh-field__input" type="number" data-dtype="Number" name="hit.totalDamage" value="{{this.hit.totalDamage}}" />


### PR DESCRIPTION
 Added damage type file to rule to allow for dropdown selection of damage type for the assign damage macro. This also allows for the display of the correct damage type and critical effects.