### PR TITLE
general small improvements

### DIFF
--- a/src/module/hooks-manager.mjs
+++ b/src/module/hooks-manager.mjs
@@ -79,6 +79,7 @@ Enable Debug with: game.dh.debug = true
         // Add custom constants for configuration.
         CONFIG.dh = DarkHeresy;
         CONFIG.Combat.initiative = { formula: '@initiative.base + @initiative.bonus', decimals: 0 };
+        CONFIG.MeasuredTemplate.defaults.angle = 30.0;
 
         // Define custom Document classes
         CONFIG.Actor.documentClass = DarkHeresyActorProxy;

--- a/src/module/rolls/damage-data.mjs
+++ b/src/module/rolls/damage-data.mjs
@@ -342,6 +342,9 @@ export class Hit {
                     const bs = sourceActor.getCharacteristicFuzzy('ballisticSkill').bonus;
                     this.addEffect(special.name, `The attack deviates [[ 1d10 - ${bs}]]m (minimum of 0m) off course to the ${scatterDirection()}!`);
                     break;
+                case 'shocking':
+                    this.addEffect(special.name, `Target must pass a Challenging (+0) Toughness test. If he fails, he suffers 1 level of Fatigue and is Stunned for a number of rounds equal to half of his degrees of failure (rounding up).`);
+                    break;
                 case 'snare':
                     this.addEffect(special.name, `Target must pass Agility test with ${special.level * -10} or become immobilised. An immobilised target can attempt no actions other than trying to escape. As a Full Action, they can make a Strength or Agility test with ${special.level * -10} to burst free or wriggle out.`);
                     break;

--- a/src/templates/actor/actor-npc-sheet.hbs
+++ b/src/templates/actor/actor-npc-sheet.hbs
@@ -35,12 +35,13 @@
 
         <section class="dh-body">
             <div class="tab" data-group="primary" data-tab="combat">
-                {{> systems/dark-heresy-2nd/templates/actor/panel/armour-display-panel.hbs}}
-                {{> systems/dark-heresy-2nd/templates/actor/panel/characteristic-roller-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/wounds-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/fatigue-panel.hbs}}
-                {{> systems/dark-heresy-2nd/templates/actor/panel/movement-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/fate-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/armour-display-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/combat-controls-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/characteristic-roller-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/movement-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/active-effects-panel.hbs}}
             </div>
             <div class="tab" data-group="primary" data-tab="main">
@@ -54,10 +55,10 @@
             <div class="tab" data-group="primary" data-tab="gear">
                 {{> systems/dark-heresy-2nd/templates/actor/panel/weapon-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/encumbrance-panel.hbs}}
-                {{> systems/dark-heresy-2nd/templates/actor/panel/backpack-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/armour-panel.hbs}}
-                {{> systems/dark-heresy-2nd/templates/actor/panel/gear-panel.hbs}}
                 {{> systems/dark-heresy-2nd/templates/actor/panel/storage-location-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/backpack-panel.hbs}}
+                {{> systems/dark-heresy-2nd/templates/actor/panel/gear-panel.hbs}}
             </div>
             <div class="tab" data-group="primary" data-tab="psychic">
                 {{> systems/dark-heresy-2nd/templates/actor/panel/psychic-powers-panel.hbs}}


### PR DESCRIPTION
I can break these out into individual smaller PRs if need be, but I figure it's fine to lump them all into one.

- Added combat controls to NPC sheets ('attack,' 'assign damage,' et al)
- Changed the default cone template angle to 30°, from Foundry's default of 53.13°. RAW, everything that expects a cone template uses a 30° cone, except for overwatch, which uses a 45° cone.
- Add the shocking effect to damage data, as it has a similar save-or-suck effect to things like flame and toxic weapons.