### PR TITLE
Fix issue #28 Can only apply damage to Linked Actors

### DIFF
--- a/src/module/documents/_module.mjs
+++ b/src/module/documents/_module.mjs
@@ -1,0 +1,5 @@
+export { DarkHeresyBaseActor } from "./base-actor.mjs";
+export { DarkHeresyAcolyte } from "./acolyte.mjs";
+export { DarkHeresyNPC } from "./npc.mjs";
+export { DarkHeresyVehicle } from "./vehicle.mjs";
+

--- a/src/module/documents/actor-proxy.mjs
+++ b/src/module/documents/actor-proxy.mjs
@@ -1,52 +1,16 @@
 import { DarkHeresyAcolyte } from './acolyte.mjs';
 import { DarkHeresyVehicle } from './vehicle.mjs';
 import { DarkHeresyNPC } from './npc.mjs';
+import { DarkHeresyBaseActor } from './base-actor.mjs';
 
-const actorMappings = {
-    'acolyte': DarkHeresyAcolyte,
-    'npc': DarkHeresyNPC,
-    'vehicle': DarkHeresyVehicle
-}
 
-export const DarkHeresyActorProxy = new Proxy(function () {}, {
-    //Will intercept calls to the "new" operator
-    construct: function (target, args) {
-        const [data] = args;
-
-        //Handle missing mapping entries
-        if (!actorMappings.hasOwnProperty(data.type))
-            throw new Error("Unsupported Entity type for create(): " + data.type);
-
-        //Return the appropriate, actual object from the right class
-        return new actorMappings[data.type](...args);
+const actorHandler = {
+    construct(_, args) {
+      const type = args[0]?.type;
+      const cls = CONFIG.Actor.documentClasses[type] ?? DarkHeresyBaseActor;
+      return new cls(...args);
     },
-    //Property access on this weird, dirty proxy object
-    get: function (target, prop, receiver) {
-        switch (prop) {
-            case "create":
-            case "createDocuments":
-                //Calling the class' create() static function
-                return function (data, options) {
-                    if (data.constructor === Array) {
-                        //Array of data, this happens when creating Actors imported from a compendium
-                        return data.map(i => DarkHeresyAcolyte.create(i, options));
-                    }
-
-                    if (!actorMappings.hasOwnProperty(data.type))
-                        throw new Error("Unsupported Entity type for create(): " + data.type);
-
-                    return actorMappings[data.type].create(data, options);
-                };
-
-            case Symbol.hasInstance:
-                //Applying the "instanceof" operator on the instance object
-                return function (instance) {
-                    return Object.values(actorMappings).some(i => instance instanceof i);
-                };
-
-            default:
-                //Just forward any requested properties to the base Actor class
-                return Actor[prop];
-        }
-    },
-});
+  };
+  
+  export const DarkHeresyActorProxy = new Proxy(DarkHeresyBaseActor, actorHandler);
+  

--- a/src/module/hooks-manager.mjs
+++ b/src/module/hooks-manager.mjs
@@ -67,7 +67,7 @@ Enable Debug with: game.dh.debug = true
 
         const consolePrefix = 'Dark Heresy | ';
         game.dh = {
-            debug: true,
+            debug: false,
             log: (s, o) => (!!game.dh.debug ? console.log(`${consolePrefix}${s}`, o) : undefined),
             warn: (s, o) => console.warn(`${consolePrefix}${s}`, o),
             error: (s, o) => console.error(`${consolePrefix}${s}`, o),
@@ -76,7 +76,7 @@ Enable Debug with: game.dh.debug = true
             rollCharacteristicMacro,
         };
 
-        CONFIG.debug.hooks = true;
+        //CONFIG.debug.hooks = true;
 
         // Add custom constants for configuration.
         CONFIG.dh = DarkHeresy;

--- a/src/module/hooks-manager.mjs
+++ b/src/module/hooks-manager.mjs
@@ -36,6 +36,8 @@ import { DarkHeresyForceFieldSheet } from './sheets/item/force-field-sheet.mjs';
 import { checkAndMigrateWorld } from './dark-heresy-migrations.mjs';
 import { DHTourMain } from './tours/main-tour.mjs';
 
+import * as documents from './documents/_module.mjs'
+
 export const SYSTEM_ID = 'dark-heresy-2nd';
 
 export class HooksManager {
@@ -65,7 +67,7 @@ Enable Debug with: game.dh.debug = true
 
         const consolePrefix = 'Dark Heresy | ';
         game.dh = {
-            debug: false,
+            debug: true,
             log: (s, o) => (!!game.dh.debug ? console.log(`${consolePrefix}${s}`, o) : undefined),
             warn: (s, o) => console.warn(`${consolePrefix}${s}`, o),
             error: (s, o) => console.error(`${consolePrefix}${s}`, o),
@@ -74,7 +76,7 @@ Enable Debug with: game.dh.debug = true
             rollCharacteristicMacro,
         };
 
-        // CONFIG.debug.hooks = true;
+        CONFIG.debug.hooks = true;
 
         // Add custom constants for configuration.
         CONFIG.dh = DarkHeresy;
@@ -83,11 +85,17 @@ Enable Debug with: game.dh.debug = true
 
         // Define custom Document classes
         CONFIG.Actor.documentClass = DarkHeresyActorProxy;
+        CONFIG.Actor.documentClasses = {
+            acolyte: documents.DarkHeresyAcolyte,
+            npc: documents.DarkHeresyNPC,
+            vehicle: documents.DarkHeresyVehicle,
+
+        };
         CONFIG.Item.documentClass = DarkHeresyItem;
 
         // Register sheet application classes
         Actors.unregisterSheet('core', ActorSheet);
-        Actors.registerSheet(SYSTEM_ID, AcolyteSheet, { makeDefault: true });
+        Actors.registerSheet(SYSTEM_ID, AcolyteSheet, {types: ["acolyte"], makeDefault: true });
         Actors.registerSheet(SYSTEM_ID, NpcSheet, {types: ['npc'], makeDefault: true });
         Actors.registerSheet(SYSTEM_ID, VehicleSheet, {types: ['vehicle'], makeDefault: true });
 

--- a/src/module/rules/homeworlds.mjs
+++ b/src/module/rules/homeworlds.mjs
@@ -130,6 +130,20 @@ export function homeworlds() {
             source: 'PG 24 EI',
         },
         {
+            name: 'Agri-World (Novo Arcadia)',
+            bonus_characteristics: ['Fellowship', 'Strength'],
+            negative_characteristic: 'Agility',
+            fate_threshold: 2,
+            emperors_blessing: 7,
+            home_world_bonus: {
+                name: 'An Unforgetable Encounter',
+                benefit: 'Due to a unfortunate encounter during warp travel which left this character scarred if they are surprised, non-surprised attackers do not gain the normal +30 bonus to their Weapon Skill and Ballistic Skill tests when targeting this character.',
+            },
+            aptitude: 'Strength',
+            wounds: '8+1d5',
+            source: 'PG 24 EI',
+        },
+        {
             name: 'Feudal World',
             bonus_characteristics: ['Perception', 'Weapon Skill'],
             negative_characteristic: 'Intelligence',


### PR DESCRIPTION
Commits on Apr 20, 2024

Added fix for issue Can only apply damage to Linked Actors #28  due to ActorProxy no longer functioning correctly after v11 update. Implimented new method of assigning sheets as found in the PF1 repo (referenced here PF1: https://gitlab.com/foundryvtt_pathfinder1e/foundryvtt-pathfinder1/-/blob/master/module/documents/item/item-proxy.mjs
https://gitlab.com/foundryvtt_pathfinder1e/foundryvtt-pathfinder1/-/blob/master/pf1.mjs?ref_type=heads#L101-114).

It involves changes to the hooks-manager and ActorProxy to add the handling of which sheet is which to the hook-manager instead of the ActorProxy code. This may need to be done for items but have not seen an issue so far.

Ignore the custom homeworld in there, I forgot to remove it.